### PR TITLE
auto check ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check
+    steps:
+      - run: exit 0
 
   check:
     name: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  ci-pass:
+    name: CI is green
+    runs-on: ubuntu-latest
+    needs:
+      - check
+
+  check:
+    name: check
+    strategy:
+      matrix:
+        config:
+          - host: ubuntu-latest
+          - host: windows-latest
+          - host: macos-latest
+    runs-on: ${{ matrix.config.host }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: check


### PR DESCRIPTION
在合并之前在会自动检查代码, 分别在macos/linux/windows运行cargo check, 并显示到checks中

![33333](https://user-images.githubusercontent.com/20847533/155511396-274b416b-41e1-4181-b7cb-f1f1cc8df4a5.png)
