### PR TITLE
添加MessageChainBuilder，优化Chain构造

### DIFF
--- a/ricq-core/src/msg/elem/anonymous.rs
+++ b/ricq-core/src/msg/elem/anonymous.rs
@@ -1,3 +1,4 @@
+use crate::msg::{MessageChainBuilder, MessageElem, PushBuilder};
 use crate::pb::msg;
 use crate::pb::msg::AnonymousGroupMessage;
 
@@ -12,9 +13,9 @@ pub struct Anonymous {
     pub color: String,
 }
 
-impl From<Anonymous> for msg::elem::Elem {
+impl From<Anonymous> for MessageElem {
     fn from(e: Anonymous) -> Self {
-        msg::elem::Elem::AnonGroupMsg(msg::AnonymousGroupMessage {
+        MessageElem::AnonGroupMsg(msg::AnonymousGroupMessage {
             flags: Some(2),
             anon_id: None,
             anon_nick: Some(e.nick.into_bytes()),
@@ -23,6 +24,12 @@ impl From<Anonymous> for msg::elem::Elem {
             bubble_id: Some(e.bubble_index),
             rank_color: Some(e.color.into_bytes()),
         })
+    }
+}
+
+impl PushBuilder for Anonymous {
+    fn push_builder(elem: Self, builder: &mut MessageChainBuilder) {
+        builder.elems.insert(0, elem.into());
     }
 }
 

--- a/ricq-core/src/msg/elem/at.rs
+++ b/ricq-core/src/msg/elem/at.rs
@@ -1,6 +1,10 @@
-use bytes::{Buf, BufMut};
 use std::fmt;
 
+use bytes::{Buf, BufMut};
+
+use crate::{push_builder_impl, to_elem_vec_impl};
+use crate::msg::{MessageElem, PushElem};
+use crate::msg::{MessageChainBuilder, PushBuilder};
 use crate::pb::msg;
 
 #[derive(Default, Debug, Clone)]
@@ -18,22 +22,22 @@ impl At {
     }
 }
 
-impl From<At> for Vec<msg::elem::Elem> {
-    fn from(e: At) -> Self {
-        vec![msg::elem::Elem::Text(msg::Text {
+impl PushElem for At {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
+        vec.push(MessageElem::Text(msg::Text {
             attr6_buf: Some({
                 let mut w = Vec::new();
                 w.put_u16(1);
                 w.put_u16(0);
-                w.put_u16(e.display.chars().count() as u16);
-                w.put_u8(if e.target == 0 { 1 } else { 0 });
-                w.put_u32(e.target as u32);
+                w.put_u16(elem.display.chars().count() as u16);
+                w.put_u8(if elem.target == 0 { 1 } else { 0 });
+                w.put_u32(elem.target as u32);
                 w.put_u16(0);
                 w
             }),
-            str: Some(e.display),
+            str: Some(elem.display),
             ..Default::default()
-        })]
+        }));
     }
 }
 
@@ -53,3 +57,6 @@ impl fmt::Display for At {
         write!(f, "[{}]", self.display)
     }
 }
+
+to_elem_vec_impl!(At);
+push_builder_impl!(At);

--- a/ricq-core/src/msg/elem/face.rs
+++ b/ricq-core/src/msg/elem/face.rs
@@ -2,6 +2,9 @@ use std::fmt;
 
 use prost::Message;
 
+use crate::{push_builder_impl, to_elem_vec_impl};
+use crate::msg::{MessageElem, PushElem};
+use crate::msg::{MessageChainBuilder, PushBuilder};
 use crate::pb::msg;
 
 #[derive(Default, Debug, Clone)]
@@ -27,9 +30,9 @@ impl Face {
     }
 }
 
-impl From<Face> for Vec<msg::elem::Elem> {
-    fn from(e: Face) -> Self {
-        vec![if e.index >= 260 {
+impl PushElem for Face {
+    fn push_to(e: Self, vec: &mut Vec<MessageElem>) {
+        let elem = if e.index >= 260 {
             let text = format!("/{}", e.name).as_bytes().to_vec();
             let elem = msg::MsgElemInfoServtype33 {
                 index: Some(e.index as u32),
@@ -37,7 +40,7 @@ impl From<Face> for Vec<msg::elem::Elem> {
                 compat: Some(text),
                 buf: None,
             }
-            .encode_to_vec();
+                .encode_to_vec();
             msg::elem::Elem::CommonElem(msg::CommonElem {
                 service_type: Some(33),
                 pb_elem: Some(elem),
@@ -49,7 +52,8 @@ impl From<Face> for Vec<msg::elem::Elem> {
                 old: Some(((0x1445 - 4 + e.index) as u16).to_be_bytes().to_vec()),
                 buf: Some(vec![0x00, 0x01, 0x00, 0x04, 0x52, 0xCC, 0xF5, 0xD0]),
             })
-        }]
+        };
+        vec.push(elem);
     }
 }
 
@@ -70,6 +74,9 @@ impl fmt::Display for Face {
         write!(f, "[{}]", self.name)
     }
 }
+
+to_elem_vec_impl!(Face);
+push_builder_impl!(Face);
 
 #[cfg(test)]
 mod tests {

--- a/ricq-core/src/msg/elem/flash_image.rs
+++ b/ricq-core/src/msg/elem/flash_image.rs
@@ -1,6 +1,9 @@
 use std::fmt;
 
+use crate::{push_builder_impl, to_elem_vec_impl};
 use crate::command::common::PbToBytes;
+use crate::msg::{MessageElem, PushElem};
+use crate::msg::{MessageChainBuilder, PushBuilder};
 use crate::msg::elem::{FriendImage, GroupImage};
 use crate::pb::msg;
 
@@ -19,10 +22,10 @@ impl FlashImage {
     }
 }
 
-impl From<FlashImage> for Vec<msg::elem::Elem> {
-    fn from(e: FlashImage) -> Self {
+impl PushElem for FlashImage {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
         let flash = {
-            match e {
+            match elem {
                 FlashImage::FriendImage(image) => msg::MsgElemInfoServtype3 {
                     flash_c2c_pic: Some(image.into()),
                     ..Default::default()
@@ -33,18 +36,17 @@ impl From<FlashImage> for Vec<msg::elem::Elem> {
                 },
             }
         }
-        .to_bytes();
-        vec![
-            msg::elem::Elem::CommonElem(msg::CommonElem {
-                service_type: Some(3),
-                pb_elem: Some(flash.to_vec()),
-                ..Default::default()
-            }),
-            msg::elem::Elem::Text(msg::Text {
-                str: Some("[闪照]请使用新版手机QQ查看闪照。".to_owned()),
-                ..Default::default()
-            }),
-        ]
+            .to_bytes();
+
+        vec.push(MessageElem::CommonElem(msg::CommonElem {
+            service_type: Some(3),
+            pb_elem: Some(flash.to_vec()),
+            ..Default::default()
+        }));
+        vec.push(MessageElem::Text(msg::Text {
+            str: Some("[闪照]请使用新版手机QQ查看闪照。".to_owned()),
+            ..Default::default()
+        }));
     }
 }
 
@@ -53,6 +55,7 @@ impl From<FriendImage> for FlashImage {
         Self::FriendImage(e)
     }
 }
+
 impl From<GroupImage> for FlashImage {
     fn from(e: GroupImage) -> Self {
         Self::GroupImage(e)
@@ -71,3 +74,6 @@ impl fmt::Display for FlashImage {
         }
     }
 }
+
+to_elem_vec_impl!(FlashImage);
+push_builder_impl!(FlashImage);

--- a/ricq-core/src/msg/elem/friend_image.rs
+++ b/ricq-core/src/msg/elem/friend_image.rs
@@ -2,6 +2,9 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+use crate::{push_builder_impl, to_elem_vec_impl};
+use crate::msg::{MessageElem, PushElem};
+use crate::msg::{MessageChainBuilder, PushBuilder};
 use crate::msg::elem::flash_image::FlashImage;
 use crate::pb::msg;
 
@@ -60,9 +63,9 @@ impl From<FriendImage> for msg::NotOnlineImage {
     }
 }
 
-impl From<FriendImage> for Vec<msg::elem::Elem> {
-    fn from(e: FriendImage) -> Vec<msg::elem::Elem> {
-        vec![msg::elem::Elem::NotOnlineImage(e.into())]
+impl PushElem for FriendImage {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
+        vec.push(MessageElem::NotOnlineImage(elem.into()));
     }
 }
 
@@ -87,3 +90,6 @@ impl fmt::Display for FriendImage {
         write!(f, "[FriendImage: {}]", self.url())
     }
 }
+
+to_elem_vec_impl!(FriendImage);
+push_builder_impl!(FriendImage);

--- a/ricq-core/src/msg/elem/group_image.rs
+++ b/ricq-core/src/msg/elem/group_image.rs
@@ -2,14 +2,18 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+use crate::{push_builder_impl, to_elem_vec_impl};
 use crate::hex::encode_hex;
+use crate::msg::{MessageElem, PushElem};
+use crate::msg::{MessageChainBuilder, PushBuilder};
 use crate::msg::elem::flash_image::FlashImage;
 use crate::pb::msg;
 use crate::pb::msg::CustomFace;
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct GroupImage {
-    pub file_path: String, // hex(md5).jpg
+    pub file_path: String,
+    // hex(md5).jpg
     pub file_id: i64,
     pub size: u32,
     pub width: u32,
@@ -17,7 +21,8 @@ pub struct GroupImage {
     pub md5: Vec<u8>,
     pub orig_url: Option<String>,
     pub image_type: i32,
-    pub signature: Vec<u8>, // highway session key
+    pub signature: Vec<u8>,
+    // highway session key
     pub server_ip: u32,
     pub server_port: u32,
 }
@@ -65,9 +70,9 @@ impl From<GroupImage> for msg::CustomFace {
     }
 }
 
-impl From<GroupImage> for Vec<msg::elem::Elem> {
-    fn from(e: GroupImage) -> Self {
-        vec![{ msg::elem::Elem::CustomFace(e.into()) }]
+impl PushElem for GroupImage {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
+        vec.push(MessageElem::CustomFace(elem.into()));
     }
 }
 
@@ -113,3 +118,6 @@ impl fmt::Display for GroupImage {
         write!(f, "[GroupImage: {}]", self.url())
     }
 }
+
+to_elem_vec_impl!(GroupImage);
+push_builder_impl!(GroupImage);

--- a/ricq-core/src/msg/elem/light_app.rs
+++ b/ricq-core/src/msg/elem/light_app.rs
@@ -1,7 +1,10 @@
 use std::io::{Read, Write};
 
-use flate2::{read::ZlibDecoder, write::ZlibEncoder, Compression};
+use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
 
+use crate::{push_builder_impl, to_elem_vec_impl};
+use crate::msg::{MessageElem, PushElem};
+use crate::msg::{MessageChainBuilder, PushBuilder};
 use crate::pb::msg;
 
 #[derive(Default, Debug, Clone)]
@@ -15,16 +18,18 @@ impl LightApp {
     }
 }
 
-impl From<LightApp> for Vec<msg::elem::Elem> {
-    fn from(e: LightApp) -> Self {
-        vec![msg::elem::Elem::LightApp(msg::LightApp {
-            data: Some({
-                let mut encoder = ZlibEncoder::new(vec![1], Compression::default());
-                encoder.write_all(e.content.as_bytes()).ok();
-                encoder.finish().unwrap_or_default()
-            }),
-            ..Default::default()
-        })]
+impl PushElem for LightApp {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
+        vec.push(
+            MessageElem::LightApp(msg::LightApp {
+                data: Some({
+                    let mut encoder = ZlibEncoder::new(vec![1], Compression::default());
+                    encoder.write_all(elem.content.as_bytes()).ok();
+                    encoder.finish().unwrap_or_default()
+                }),
+                ..Default::default()
+            })
+        );
     }
 }
 
@@ -50,3 +55,6 @@ impl From<msg::LightApp> for LightApp {
         Self::default()
     }
 }
+
+to_elem_vec_impl!(LightApp);
+push_builder_impl!(LightApp);

--- a/ricq-core/src/msg/elem/market_face.rs
+++ b/ricq-core/src/msg/elem/market_face.rs
@@ -1,5 +1,8 @@
 use derivative;
 
+use crate::{push_builder_impl, to_elem_vec_impl};
+use crate::msg::{MessageElem, PushElem};
+use crate::msg::{MessageChainBuilder, PushBuilder};
 use crate::pb::msg;
 
 // 不需要实现 Display，因为后面一定会跟 Text
@@ -15,28 +18,28 @@ pub struct MarketFace {
     pub magic_value: String,
 }
 
-impl From<MarketFace> for Vec<msg::elem::Elem> {
-    fn from(e: MarketFace) -> Self {
-        vec![
-            msg::elem::Elem::MarketFace(msg::MarketFace {
-                face_name: Some(e.name.as_bytes().to_vec()),
-                item_type: Some(e.item_type as u32),
-                face_info: Some(1),
-                face_id: Some(e.face_id),
-                tab_id: Some(e.tab_id as u32),
-                sub_type: Some(e.sub_type as u32),
-                key: Some(e.encrypt_key),
-                media_type: Some(e.media_type as u32),
-                image_width: Some(200),
-                image_height: Some(200),
-                mobileparam: Some(e.magic_value.as_bytes().to_vec()),
+impl PushElem for MarketFace {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
+        vec.push(MessageElem::MarketFace(msg::MarketFace {
+            face_name: Some(elem.name.as_bytes().to_vec()),
+            item_type: Some(elem.item_type as u32),
+            face_info: Some(1),
+            face_id: Some(elem.face_id),
+            tab_id: Some(elem.tab_id as u32),
+            sub_type: Some(elem.sub_type as u32),
+            key: Some(elem.encrypt_key),
+            media_type: Some(elem.media_type as u32),
+            image_width: Some(200),
+            image_height: Some(200),
+            mobileparam: Some(elem.magic_value.as_bytes().to_vec()),
+            ..Default::default()
+        }));
+        vec.push(
+            MessageElem::Text(msg::Text {
+                str: Some(elem.name),
                 ..Default::default()
-            }),
-            msg::elem::Elem::Text(msg::Text {
-                str: Some(e.name),
-                ..Default::default()
-            }),
-        ]
+            })
+        );
     }
 }
 
@@ -65,6 +68,7 @@ impl Dice {
         Self { value }
     }
 }
+
 impl From<Dice> for MarketFace {
     fn from(e: Dice) -> Self {
         Self {
@@ -95,9 +99,9 @@ impl From<MarketFace> for Dice {
     }
 }
 
-impl From<Dice> for Vec<msg::elem::Elem> {
-    fn from(e: Dice) -> Self {
-        MarketFace::from(e).into()
+impl PushElem for Dice {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
+        MarketFace::push_to(MarketFace::from(elem), vec);
     }
 }
 
@@ -109,6 +113,7 @@ pub enum FingerGuessing {
     Scissors,
     Paper,
 }
+
 impl From<FingerGuessing> for MarketFace {
     fn from(e: FingerGuessing) -> Self {
         let value = match e {
@@ -133,9 +138,9 @@ impl From<FingerGuessing> for MarketFace {
     }
 }
 
-impl From<FingerGuessing> for Vec<msg::elem::Elem> {
-    fn from(e: FingerGuessing) -> Self {
-        MarketFace::from(e).into()
+impl PushElem for FingerGuessing {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
+        MarketFace::push_to(MarketFace::from(elem), vec);
     }
 }
 
@@ -152,3 +157,12 @@ impl From<MarketFace> for FingerGuessing {
         }
     }
 }
+
+to_elem_vec_impl!(MarketFace);
+push_builder_impl!(MarketFace);
+
+to_elem_vec_impl!(Dice);
+push_builder_impl!(Dice);
+
+to_elem_vec_impl!(FingerGuessing);
+push_builder_impl!(FingerGuessing);

--- a/ricq-core/src/msg/elem/mod.rs
+++ b/ricq-core/src/msg/elem/mod.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use prost::Message;
 
 pub use group_image::calculate_image_resource_id;
+pub(crate) use text::flush_builder;
 
 pub use crate::msg::elem::{
     anonymous::Anonymous,

--- a/ricq-core/src/msg/elem/reply.rs
+++ b/ricq-core/src/msg/elem/reply.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::msg::{MessageChainBuilder, MessageElem, PushBuilder};
 use crate::pb::msg;
 
 use super::super::MessageChain;
@@ -12,9 +13,9 @@ pub struct Reply {
     pub elements: MessageChain,
 }
 
-impl From<Reply> for msg::elem::Elem {
+impl From<Reply> for MessageElem {
     fn from(e: Reply) -> Self {
-        msg::elem::Elem::SrcMsg(msg::SourceMsg {
+        MessageElem::SrcMsg(msg::SourceMsg {
             orig_seqs: vec![e.reply_seq],
             sender_uin: Some(e.sender),
             time: Some(e.time),
@@ -26,6 +27,15 @@ impl From<Reply> for msg::elem::Elem {
             troop_name: Some(vec![]),
             ..Default::default()
         })
+    }
+}
+
+impl PushBuilder for Reply {
+    fn push_builder(elem: Self, builder: &mut MessageChainBuilder) {
+        let index = if let Some(MessageElem::AnonGroupMsg(..)) = builder.elems.get(0) {
+            1
+        } else { 0 };
+        builder.elems.insert(index, elem.into());
     }
 }
 

--- a/ricq-core/src/msg/elem/rich_msg.rs
+++ b/ricq-core/src/msg/elem/rich_msg.rs
@@ -1,29 +1,18 @@
 use std::io::{Read, Write};
 
+use flate2::Compression;
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
-use flate2::Compression;
 
+use crate::{push_builder_impl, to_elem_vec_impl};
+use crate::msg::{MessageElem, PushElem};
+use crate::msg::{MessageChainBuilder, PushBuilder};
 use crate::pb::msg;
 
 #[derive(Default, Debug, Clone)]
 pub struct RichMsg {
     pub service_id: i32,
     pub template1: String,
-}
-
-impl From<RichMsg> for Vec<msg::elem::Elem> {
-    fn from(e: RichMsg) -> Self {
-        vec![msg::elem::Elem::RichMsg(msg::RichMsg {
-            template1: Some({
-                let mut encoder = ZlibEncoder::new(vec![1], Compression::default());
-                encoder.write_all(e.template1.as_bytes()).ok();
-                encoder.finish().unwrap_or_default()
-            }),
-            service_id: Some(e.service_id),
-            ..Default::default()
-        })]
-    }
 }
 
 impl From<msg::RichMsg> for RichMsg {
@@ -49,3 +38,20 @@ impl From<msg::RichMsg> for RichMsg {
         Self::default()
     }
 }
+
+impl PushElem for RichMsg {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
+        vec.push(MessageElem::RichMsg(msg::RichMsg {
+            template1: Some({
+                let mut encoder = ZlibEncoder::new(vec![1], Compression::default());
+                encoder.write_all(elem.template1.as_bytes()).ok();
+                encoder.finish().unwrap_or_default()
+            }),
+            service_id: Some(elem.service_id),
+            ..Default::default()
+        }));
+    }
+}
+
+to_elem_vec_impl!(RichMsg);
+push_builder_impl!(RichMsg);

--- a/ricq-core/src/msg/elem/text.rs
+++ b/ricq-core/src/msg/elem/text.rs
@@ -1,6 +1,8 @@
-use std::fmt;
+use std::{fmt, mem};
 
+use crate::msg::{MessageChainBuilder, MessageElem, PushBuilder, PushElem};
 use crate::pb::msg;
+use crate::to_elem_vec_impl;
 
 #[derive(Default, Debug, Clone)]
 pub struct Text {
@@ -13,20 +15,40 @@ impl Text {
     }
 }
 
-impl From<Text> for Vec<msg::elem::Elem> {
-    fn from(e: Text) -> Self {
-        vec![msg::elem::Elem::Text(msg::Text {
-            str: Some(e.content),
-            ..Default::default()
-        })]
-    }
-}
+to_elem_vec_impl!(Text);
 
 impl From<msg::Text> for Text {
     fn from(e: msg::Text) -> Self {
         Self {
             content: e.str.unwrap_or_default(),
         }
+    }
+}
+
+impl PushElem for Text {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
+        vec.push(MessageElem::Text(msg::Text {
+            str: Some(elem.content),
+            ..Default::default()
+        }));
+    }
+}
+
+impl PushBuilder for Text {
+    fn push_builder(elem: Self, builder: &mut MessageChainBuilder) {
+        builder.buf_string.push_str(&elem.content);
+    }
+}
+
+pub fn flush_builder(builder: &mut MessageChainBuilder) {
+    if !builder.buf_string.is_empty() {
+        let s = mem::take(&mut builder.buf_string);
+        builder.elems.push(
+            MessageElem::Text(msg::Text {
+                str: Some(s),
+                ..Default::default()
+            })
+        );
     }
 }
 

--- a/ricq-core/src/msg/elem/video_file.rs
+++ b/ricq-core/src/msg/elem/video_file.rs
@@ -1,6 +1,9 @@
 use std::fmt;
 
+use crate::{push_builder_impl, to_elem_vec_impl};
 use crate::hex::encode_hex;
+use crate::msg::{MessageElem, PushElem};
+use crate::msg::{MessageChainBuilder, PushBuilder};
 use crate::pb::msg;
 
 #[derive(Default, Debug, Clone)]
@@ -11,38 +14,6 @@ pub struct VideoFile {
     pub thumb_size: i32,
     pub md5: Vec<u8>,
     pub thumb_md5: Vec<u8>,
-}
-
-impl From<VideoFile> for Vec<msg::elem::Elem> {
-    fn from(e: VideoFile) -> Self {
-        vec![
-            msg::elem::Elem::Text(msg::Text {
-                str: Some("你的QQ暂不支持查看视频短片，请期待后续版本。".into()),
-                ..Default::default()
-            }),
-            msg::elem::Elem::VideoFile(msg::VideoFile {
-                file_uuid: Some(e.uuid),
-                file_name: Some(format!("{}.mp4", encode_hex(&e.md5))),
-                file_md5: Some(e.md5),
-                file_format: Some(3),
-                file_time: Some(10),
-                file_size: Some(e.size),
-                thumb_width: Some(1280),
-                thumb_height: Some(720),
-                thumb_file_md5: Some(e.thumb_md5),
-                thumb_file_size: Some(e.thumb_size),
-                busi_type: Some(0), // guild 4601
-                from_chat_type: Some(-1),
-                to_chat_type: Some(-1),
-                bool_support_progressive: Some(true),
-                file_width: Some(1280), // guild 0
-                file_height: Some(720), // guild 0
-                sub_busi_type: None,    // guild 4601
-                video_attr: None,       // guild 0
-                ..Default::default()
-            }),
-        ]
-    }
 }
 
 impl From<msg::VideoFile> for VideoFile {
@@ -58,8 +29,45 @@ impl From<msg::VideoFile> for VideoFile {
     }
 }
 
+impl PushElem for VideoFile {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>) {
+        vec.push(
+            MessageElem::Text(msg::Text {
+                str: Some("你的QQ暂不支持查看视频短片，请期待后续版本。".into()),
+                ..Default::default()
+            })
+        );
+        vec.push(
+            MessageElem::VideoFile(msg::VideoFile {
+                file_uuid: Some(elem.uuid),
+                file_name: Some(format!("{}.mp4", encode_hex(&elem.md5))),
+                file_md5: Some(elem.md5),
+                file_format: Some(3),
+                file_time: Some(10),
+                file_size: Some(elem.size),
+                thumb_width: Some(1280),
+                thumb_height: Some(720),
+                thumb_file_md5: Some(elem.thumb_md5),
+                thumb_file_size: Some(elem.thumb_size),
+                busi_type: Some(0), // guild 4601
+                from_chat_type: Some(-1),
+                to_chat_type: Some(-1),
+                bool_support_progressive: Some(true),
+                file_width: Some(1280), // guild 0
+                file_height: Some(720), // guild 0
+                sub_busi_type: None,    // guild 4601
+                video_attr: None,       // guild 0
+                ..Default::default()
+            })
+        );
+    }
+}
+
 impl fmt::Display for VideoFile {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[VideoFile: {}]", self.name)
     }
 }
+
+to_elem_vec_impl!(VideoFile);
+push_builder_impl!(VideoFile);

--- a/ricq-core/src/msg/macros.rs
+++ b/ricq-core/src/msg/macros.rs
@@ -1,0 +1,24 @@
+#[macro_export]
+macro_rules! to_elem_vec_impl {
+    ($t:ty) => {
+        impl From<$t> for Vec<MessageElem> {
+            fn from(e: $t) -> Self {
+                let mut vec = vec![];
+                <$t>::push_to(e, &mut vec);
+                vec
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! push_builder_impl {
+    ($t:ty) => {
+        impl PushBuilder for $t {
+            fn push_builder(elem: Self, builder: &mut MessageChainBuilder) {
+                builder.flush();
+                Self::push_to(elem, &mut builder.elems);
+            }
+        }
+    }
+}

--- a/ricq-core/src/msg/mod.rs
+++ b/ricq-core/src/msg/mod.rs
@@ -1,68 +1,71 @@
 use std::fmt;
 
-use elem::RQElem;
 use elem::*;
+use elem::RQElem;
 
 use crate::pb::msg;
 
 pub mod elem;
 mod fragment;
+mod macros;
+
+pub type MessageElem = msg::elem::Elem;
 
 #[derive(Debug, Default, Clone)]
-pub struct MessageChain(pub Vec<msg::elem::Elem>);
+pub struct MessageChain(pub Vec<MessageElem>);
 
 impl MessageChain {
-    pub fn new<E: Into<Vec<msg::elem::Elem>>>(e: E) -> Self {
+    pub fn new<E: Into<Vec<MessageElem>>>(e: E) -> Self {
         Self(e.into())
     }
 
-    pub fn push<E: Into<Vec<msg::elem::Elem>>>(&mut self, e: E) {
+    pub fn push<E: Into<Vec<MessageElem>>>(&mut self, e: E) {
         self.0.extend(e.into())
     }
 
     pub fn anonymous(&self) -> Option<Anonymous> {
         self.0.iter().find_map(|e| match e {
-            msg::elem::Elem::AnonGroupMsg(anonymous) => Some(Anonymous::from(anonymous.clone())),
+            MessageElem::AnonGroupMsg(anonymous) => Some(Anonymous::from(anonymous.clone())),
             _ => None,
         })
     }
 
     pub fn reply(&self) -> Option<Reply> {
         self.0.iter().find_map(|e| match e {
-            msg::elem::Elem::SrcMsg(src_msg) => Some(Reply::from(src_msg.clone())),
+            MessageElem::SrcMsg(src_msg) => Some(Reply::from(src_msg.clone())),
             _ => None,
         })
     }
 
     pub fn with_anonymous(&mut self, anonymous: Anonymous) {
-        self.0.insert(0, msg::elem::Elem::from(anonymous))
+        self.0.insert(0, MessageElem::from(anonymous))
     }
 
     pub fn with_reply(&mut self, reply: Reply) {
         let index = if self.anonymous().is_some() { 1 } else { 0 };
-        self.0.insert(index, msg::elem::Elem::from(reply))
+        self.0.insert(index, MessageElem::from(reply))
     }
 }
 
 impl<E> FromIterator<E> for MessageChain
-where
-    E: Into<Vec<msg::elem::Elem>>,
+    where
+        E: Into<Vec<MessageElem>>,
 {
-    fn from_iter<T: IntoIterator<Item = E>>(iter: T) -> Self {
+    fn from_iter<T: IntoIterator<Item=E>>(iter: T) -> Self {
         Self(iter.into_iter().flat_map(Into::into).collect())
     }
 }
 
 impl IntoIterator for MessageChain {
     type Item = RQElem;
-    type IntoIter = impl Iterator<Item = RQElem> + 'static;
+    type IntoIter = impl Iterator<Item=RQElem> + 'static;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0
             .into_iter()
             .filter_map(|e| match e {
-                msg::elem::Elem::SrcMsg(_) => None,
-                msg::elem::Elem::AnonGroupMsg(_) => None,
+                MessageElem::SrcMsg(_) => None,
+                MessageElem::AnonGroupMsg(_) => None,
                 _ => Some(e),
             })
             .map(RQElem::from)
@@ -90,6 +93,45 @@ impl fmt::Display for MessageChain {
         }
         Ok(())
     }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct MessageChainBuilder {
+    pub elems: Vec<MessageElem>,
+    pub buf_string: String,
+}
+
+impl MessageChainBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push<E: PushBuilder>(&mut self, elem: E) -> &mut Self {
+        E::push_builder(elem, self);
+        self
+    }
+
+    pub fn push_str(&mut self, str: &str) -> &mut Self {
+        self.buf_string.push_str(str);
+        self
+    }
+
+    pub fn build(mut self) -> MessageChain {
+        self.flush();
+        MessageChain::new(self.elems)
+    }
+
+    fn flush(&mut self) {
+        flush_builder(self);
+    }
+}
+
+pub trait PushElem {
+    fn push_to(elem: Self, vec: &mut Vec<MessageElem>);
+}
+
+pub trait PushBuilder {
+    fn push_builder(elem: Self, builder: &mut MessageChainBuilder);
 }
 
 #[cfg(test)]
@@ -124,6 +166,33 @@ mod tests {
         println!("{}", chain);
         println!("{:?}", chain.reply());
         println!("{:?}", chain.anonymous());
+        for item in chain {
+            println!("{:?}", item)
+        }
+    }
+
+    #[test]
+    fn test_builder() {
+        let mut builder = MessageChainBuilder::new();
+        builder.push(Anonymous::default());
+        builder.push(Reply::default());
+        builder.push_str("hello");
+        builder.push(At::new(12345));
+        builder.push_str("world");
+        builder.push(Face::new(1));
+        builder.push(Dice::new(1));
+        builder.push(Text::new("hello".into()));
+        builder.push_str("world2");
+        builder.push(FingerGuessing::Rock);
+        builder.push(MarketFace {
+            name: "xx".into(),
+            ..Default::default()
+        });
+        builder.push(LightApp::new("{}".into()));
+        let chain = builder.build();
+        println!("{}", chain);
+        assert!(chain.reply().is_some());
+        assert!(chain.anonymous().is_some());
         for item in chain {
             println!("{:?}", item)
         }


### PR DESCRIPTION
1.提供PushBuilder trait，将消息元素直接添加在Vec上，优化性能
2.为`msg::elem::Elem`定义Type`MessageElem`
3.原有MessageChain兼容，添加测试