### PR TITLE
refactor `Handler`

### DIFF
--- a/ricq/src/client/handler/mod.rs
+++ b/ricq/src/client/handler/mod.rs
@@ -51,18 +51,60 @@ pub enum QEvent {
     DeleteFriend(DeleteFriendEvent),
     /// 群成员权限变更
     MemberPermissionChange(MemberPermissionChangeEvent),
-    /// 被其他客户端踢下线
-    /// 不能用于掉线重连，掉线重连以 start 返回为准
+    /// 被其他客户端踢下线。**不能用于掉线重连，掉线重连以 start 返回为准**
     KickedOffline(KickedOfflineEvent),
-    /// 服务端强制下线
-    /// 不能用于掉线重连，掉线重连以 start 返回为准
+    /// 服务端强制下线。**不能用于掉线重连，掉线重连以 start 返回为准**
     MSFOffline(MSFOfflineEvent),
 }
 
-/// 处理外发数据的接口
+/// 事件处理器。
+/// 
+/// 接收到事件时，事件类型对应的 `fn handle_ ...` 会被调用。默认情况下，所有事件处理函数都实现为：将事件包装成 QEvent 并转发到 `async fn handle(&self, e: QEvent)`。
+/// 
+/// # 示例
+/// 
+/// ```
+/// struct MyHandler;
+/// #[async_trait]
+/// impl Handler for MyHandler {
+///     /// 群消息事件
+///     async fn handle_group_message(&self, e: GroupMessageEvent) {
+///         tracing::info!("MyHandler::handle_group_message: {:?}", e.inner);
+///         // 这里没有转发到 fn handle，所以 handle 只能收到……
+///     }
+///     /// 除 群消息 外所有事件
+///     async fn handle(&self, e: QEvent) {
+///         tracing::info!("MyHandler::handle: {:?}", e);
+///     }
+/// }
+/// ```
+#[rustfmt::skip]
 #[async_trait]
 pub trait Handler: Sync {
-    async fn handle(&self, event: QEvent);
+    /// 默认情况下，所有事件都会被包装为 QEvent 并在这里接收
+    async fn handle(&self, e: QEvent); // 不默认实现，提醒用户还有其他事件
+    async fn handle_login(&self, e: i64) { self.handle(QEvent::Login(e)).await }
+    async fn handle_group_message(&self, e: GroupMessageEvent) { self.handle(QEvent::GroupMessage(e)).await }
+    async fn handle_group_audio(&self, e: GroupAudioMessageEvent) { self.handle(QEvent::GroupAudioMessage(e)).await }
+    async fn handle_friend_message(&self, e: FriendMessageEvent) { self.handle(QEvent::FriendMessage(e)).await }
+    async fn handle_friend_audio(&self, e: FriendAudioMessageEvent) { self.handle(QEvent::FriendAudioMessage(e)).await }
+    async fn handle_group_temp_message(&self, e: GroupTempMessageEvent) { self.handle(QEvent::GroupTempMessage(e)).await }
+    async fn handle_group_request(&self, e: JoinGroupRequestEvent) { self.handle(QEvent::GroupRequest(e)).await }
+    async fn handle_self_invited(&self, e: SelfInvitedEvent) { self.handle(QEvent::SelfInvited(e)).await }
+    async fn handle_friend_request(&self, e: NewFriendRequestEvent) { self.handle(QEvent::NewFriendRequest(e)).await }
+    async fn handle_new_member(&self, e: NewMemberEvent) { self.handle(QEvent::NewMember(e)).await }
+    async fn handle_group_mute(&self, e: GroupMuteEvent) { self.handle(QEvent::GroupMute(e)).await }
+    async fn handle_friend_message_recall(&self, e: FriendMessageRecallEvent) { self.handle(QEvent::FriendMessageRecall(e)).await }
+    async fn handle_group_message_recall(&self, e: GroupMessageRecallEvent) { self.handle(QEvent::GroupMessageRecall(e)).await }
+    async fn handle_new_friend(&self, e: NewFriendEvent) { self.handle(QEvent::NewFriend(e)).await }
+    async fn handle_group_leave(&self, e: GroupLeaveEvent) { self.handle(QEvent::GroupLeave(e)).await }
+    async fn handle_group_disband(&self, e: GroupDisbandEvent) { self.handle(QEvent::GroupDisband(e)).await }
+    async fn handle_friend_poke(&self, e: FriendPokeEvent) { self.handle(QEvent::FriendPoke(e)).await }
+    async fn handle_group_name_update(&self, e: GroupNameUpdateEvent) { self.handle(QEvent::GroupNameUpdate(e)).await }
+    async fn handle_delete_friend(&self, e: DeleteFriendEvent) { self.handle(QEvent::DeleteFriend(e)).await }
+    async fn handle_member_permission_change(&self, e: MemberPermissionChangeEvent) { self.handle(QEvent::MemberPermissionChange(e)).await }
+    async fn handle_kicked_offline(&self, e: KickedOfflineEvent) { self.handle(QEvent::KickedOffline(e)).await }
+    async fn handle_msf_offline(&self, e: MSFOfflineEvent) { self.handle(QEvent::MSFOffline(e)).await }
 }
 
 /// 一个默认 Handler，只是把信息打印出来
@@ -70,38 +112,24 @@ pub struct DefaultHandler;
 
 #[async_trait]
 impl Handler for DefaultHandler {
+    async fn handle_group_message(&self, e: GroupMessageEvent) {
+        tracing::info!("DefaultHandler::handle_group_message: {:?}", e.inner);
+    }
+    async fn handle_group_temp_message(&self, e: GroupTempMessageEvent) {
+        tracing::info!("DefaultHandler::handle_group_temp_message: {:?}", e.inner);
+    }
+    async fn handle_friend_message(&self, e: FriendMessageEvent) {
+        tracing::info!("DefaultHandler::handle_friend_message: {:?}", e.inner);
+    }
+    async fn handle_group_request(&self, e: JoinGroupRequestEvent) {
+        tracing::info!("DefaultHandler::handle_group_request: {:?}", e.inner);
+    }
+    async fn handle_friend_request(&self, e: NewFriendRequestEvent) {
+        tracing::info!("DefaultHandler::handle_friend_request: {:?}", e.inner);
+    }
+    /// 其他事件在这里输出
     async fn handle(&self, e: QEvent) {
-        match e {
-            QEvent::GroupMessage(m) => {
-                tracing::info!(
-                    "MESSAGE (GROUP={}): {}",
-                    m.inner.group_code,
-                    m.inner.elements
-                )
-            }
-            QEvent::FriendMessage(m) => {
-                tracing::info!(
-                    "MESSAGE (FRIEND={}): {}",
-                    m.inner.from_uin,
-                    m.inner.elements
-                )
-            }
-            QEvent::GroupTempMessage(m) => {
-                tracing::info!("MESSAGE (TEMP={}): {}", m.inner.from_uin, m.inner.elements)
-            }
-            QEvent::GroupRequest(m) => {
-                tracing::info!(
-                    "REQUEST (GROUP={}, UIN={}): {}",
-                    m.inner.group_code,
-                    m.inner.req_uin,
-                    m.inner.message
-                )
-            }
-            QEvent::NewFriendRequest(m) => {
-                tracing::info!("REQUEST (UIN={}): {}", m.inner.req_uin, m.inner.message)
-            }
-            _ => tracing::info!("{:?}", e),
-        }
+        tracing::info!("DefaultHandler::handle: {:?}", e);
     }
 }
 
@@ -130,64 +158,5 @@ impl Handler for UnboundedSender<QEvent> {
 impl Handler for WatchSender<QEvent> {
     async fn handle(&self, msg: QEvent) {
         self.send(msg).ok();
-    }
-}
-
-#[async_trait]
-pub trait PartlyHandler: Sync {
-    async fn handle_login(&self, _: i64) {}
-    async fn handle_group_message(&self, _event: GroupMessageEvent) {}
-    async fn handle_group_audio(&self, _event: GroupAudioMessageEvent) {}
-    async fn handle_friend_message(&self, _event: FriendMessageEvent) {}
-    async fn handle_friend_audio(&self, _event: FriendAudioMessageEvent) {}
-    async fn handle_group_temp_message(&self, _event: GroupTempMessageEvent) {}
-    async fn handle_group_request(&self, _event: JoinGroupRequestEvent) {}
-    async fn handle_self_invited(&self, _event: SelfInvitedEvent) {}
-    async fn handle_friend_request(&self, _event: NewFriendRequestEvent) {}
-    async fn handle_new_member(&self, _event: NewMemberEvent) {}
-    async fn handle_group_mute(&self, _event: GroupMuteEvent) {}
-    async fn handle_friend_message_recall(&self, _event: FriendMessageRecallEvent) {}
-    async fn handle_group_message_recall(&self, _event: GroupMessageRecallEvent) {}
-    async fn handle_new_friend(&self, _event: NewFriendEvent) {}
-    async fn handle_group_leave(&self, _event: GroupLeaveEvent) {}
-    async fn handle_group_disband(&self, _event: GroupDisbandEvent) {}
-    async fn handle_friend_poke(&self, _event: FriendPokeEvent) {}
-    async fn handle_group_name_update(&self, _event: GroupNameUpdateEvent) {}
-    async fn handle_delete_friend(&self, _event: DeleteFriendEvent) {}
-    async fn handle_member_permission_change(&self, _event: MemberPermissionChangeEvent) {}
-    async fn handle_kicked_offline(&self, _event: KickedOfflineEvent) {}
-    async fn handle_msf_offline(&self, _event: MSFOfflineEvent) {}
-}
-
-#[async_trait]
-impl<PH> Handler for PH
-where
-    PH: PartlyHandler,
-{
-    async fn handle(&self, event: QEvent) {
-        match event {
-            QEvent::Login(uin) => self.handle_login(uin).await,
-            QEvent::GroupMessage(m) => self.handle_group_message(m).await,
-            QEvent::GroupAudioMessage(m) => self.handle_group_audio(m).await,
-            QEvent::FriendMessage(m) => self.handle_friend_message(m).await,
-            QEvent::FriendAudioMessage(m) => self.handle_friend_audio(m).await,
-            QEvent::GroupTempMessage(m) => self.handle_group_temp_message(m).await,
-            QEvent::GroupRequest(m) => self.handle_group_request(m).await,
-            QEvent::SelfInvited(m) => self.handle_self_invited(m).await,
-            QEvent::NewFriendRequest(m) => self.handle_friend_request(m).await,
-            QEvent::NewMember(m) => self.handle_new_member(m).await,
-            QEvent::GroupMute(m) => self.handle_group_mute(m).await,
-            QEvent::FriendMessageRecall(m) => self.handle_friend_message_recall(m).await,
-            QEvent::GroupMessageRecall(m) => self.handle_group_message_recall(m).await,
-            QEvent::NewFriend(m) => self.handle_new_friend(m).await,
-            QEvent::GroupLeave(m) => self.handle_group_leave(m).await,
-            QEvent::GroupDisband(m) => self.handle_group_disband(m).await,
-            QEvent::FriendPoke(m) => self.handle_friend_poke(m).await,
-            QEvent::GroupNameUpdate(m) => self.handle_group_name_update(m).await,
-            QEvent::DeleteFriend(m) => self.handle_delete_friend(m).await,
-            QEvent::MemberPermissionChange(m) => self.handle_member_permission_change(m).await,
-            QEvent::KickedOffline(m) => self.handle_kicked_offline(m).await,
-            QEvent::MSFOffline(m) => self.handle_msf_offline(m).await,
-        }
     }
 }

--- a/ricq/src/client/processor/c2c/friend_msg.rs
+++ b/ricq/src/client/processor/c2c/friend_msg.rs
@@ -6,7 +6,6 @@ use ricq_core::structs::{FriendAudio, FriendAudioMessage, FriendMessage};
 use ricq_core::{pb, RQResult};
 
 use crate::client::event::{FriendAudioMessageEvent, FriendMessageEvent};
-use crate::handler::QEvent;
 use crate::Client;
 
 impl Client {
@@ -20,10 +19,10 @@ impl Client {
         if let Some(ptt) = take_ptt(&mut msg) {
             // TODO self friend audio
             self.handler
-                .handle(QEvent::FriendAudioMessage(FriendAudioMessageEvent {
+                .handle_friend_audio(FriendAudioMessageEvent {
                     client: self.clone(),
                     inner: parse_friend_audio_message(msg, ptt)?,
-                }))
+                })
                 .await;
             return Ok(());
         }
@@ -41,10 +40,10 @@ impl Client {
             }
         }
         self.handler
-            .handle(QEvent::FriendMessage(FriendMessageEvent {
+            .handle_friend_message(FriendMessageEvent {
                 client: self.clone(),
                 inner: message,
-            }))
+            })
             .await;
         Ok(())
     }

--- a/ricq/src/client/processor/c2c/friend_system_msg.rs
+++ b/ricq/src/client/processor/c2c/friend_system_msg.rs
@@ -1,5 +1,4 @@
 use crate::client::event::NewFriendRequestEvent;
-use crate::handler::QEvent;
 use crate::Client;
 use ricq_core::command::profile_service::FriendSystemMessages;
 use std::sync::Arc;
@@ -11,10 +10,10 @@ impl Client {
     ) {
         for request in msgs.requests {
             self.handler
-                .handle(QEvent::NewFriendRequest(NewFriendRequestEvent {
+                .handle_friend_request(NewFriendRequestEvent {
                     client: self.clone(),
                     inner: request,
-                }))
+                })
                 .await;
         }
     }

--- a/ricq/src/client/processor/c2c/group_system_msg.rs
+++ b/ricq/src/client/processor/c2c/group_system_msg.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use ricq_core::command::profile_service::GroupSystemMessages;
 
 use crate::client::event::{JoinGroupRequestEvent, SelfInvitedEvent};
-use crate::handler::QEvent;
 use crate::Client;
 
 impl Client {
@@ -16,10 +15,10 @@ impl Client {
                 continue;
             }
             self.handler
-                .handle(QEvent::SelfInvited(SelfInvitedEvent {
+                .handle_self_invited(SelfInvitedEvent {
                     client: self.clone(),
                     inner: request,
-                }))
+                })
                 .await;
         }
         for request in msgs.join_group_requests.clone() {
@@ -30,10 +29,10 @@ impl Client {
                 continue;
             }
             self.handler
-                .handle(QEvent::GroupRequest(JoinGroupRequestEvent {
+                .handle_group_request(JoinGroupRequestEvent {
                     client: self.clone(),
                     inner: request,
-                }))
+                })
                 .await;
         }
         let mut cache = self.group_sys_message_cache.write().await;

--- a/ricq/src/client/processor/c2c/new_member.rs
+++ b/ricq/src/client/processor/c2c/new_member.rs
@@ -5,7 +5,6 @@ use ricq_core::structs::NewMember;
 use ricq_core::{pb, RQError, RQResult};
 
 use crate::client::event::NewMemberEvent;
-use crate::handler::QEvent;
 use crate::Client;
 
 impl Client {
@@ -18,13 +17,13 @@ impl Client {
         let member_uin = head.auth_uin();
 
         self.handler
-            .handle(QEvent::NewMember(NewMemberEvent {
+            .handle_new_member(NewMemberEvent {
                 client: self.clone(),
                 inner: NewMember {
                     group_code,
                     member_uin,
                 },
-            }))
+            })
             .await;
 
         Ok(())

--- a/ricq/src/client/processor/c2c/temp_session.rs
+++ b/ricq/src/client/processor/c2c/temp_session.rs
@@ -5,7 +5,6 @@ use ricq_core::structs::GroupTempMessage;
 use ricq_core::{pb, RQError, RQResult};
 
 use crate::client::event::GroupTempMessageEvent;
-use crate::handler::QEvent;
 use crate::Client;
 
 impl Client {
@@ -15,10 +14,10 @@ impl Client {
     ) -> RQResult<()> {
         let message = parse_temp_message(msg)?;
         self.handler
-            .handle(QEvent::GroupTempMessage(GroupTempMessageEvent {
+            .handle_group_temp_message(GroupTempMessageEvent {
                 client: self.clone(),
                 inner: message,
-            }))
+            })
             .await;
         Ok(())
     }

--- a/ricq/src/client/processor/message_svc.rs
+++ b/ricq/src/client/processor/message_svc.rs
@@ -8,7 +8,6 @@ use ricq_core::{jce, pb};
 
 use crate::client::event::KickedOfflineEvent;
 use crate::client::NetworkStatus;
-use crate::handler::QEvent;
 use crate::Client;
 
 impl Client {
@@ -58,10 +57,10 @@ impl Client {
     ) {
         self.stop(NetworkStatus::KickedOffline);
         self.handler
-            .handle(QEvent::KickedOffline(KickedOfflineEvent {
+            .handle_kicked_offline(KickedOfflineEvent {
                 client: self.clone(),
                 inner: offline,
-            }))
+            })
             .await;
     }
 

--- a/ricq/src/client/processor/stat_svc.rs
+++ b/ricq/src/client/processor/stat_svc.rs
@@ -4,7 +4,6 @@ use ricq_core::jce;
 
 use crate::client::event::MSFOfflineEvent;
 use crate::client::{Client, NetworkStatus};
-use crate::handler::QEvent;
 
 impl Client {
     // TODO 待测试
@@ -17,10 +16,10 @@ impl Client {
             .ok();
         self.stop(NetworkStatus::MsfOffline);
         self.handler
-            .handle(QEvent::MSFOffline(MSFOfflineEvent {
+            .handle_msf_offline(MSFOfflineEvent {
                 client: self.clone(),
                 inner: offline,
-            }))
+            })
             .await;
     }
 }

--- a/ricq/src/client/processor/wtlogin.rs
+++ b/ricq/src/client/processor/wtlogin.rs
@@ -1,4 +1,3 @@
-use crate::handler::QEvent;
 use crate::Client;
 use ricq_core::command::wtlogin::*;
 
@@ -16,7 +15,7 @@ impl Client {
             .write()
             .await
             .process_login_response(login_response);
-        self.handler.handle(QEvent::Login(self.uin().await)).await;
+        self.handler.handle_login(self.uin().await).await;
     }
 
     pub(crate) async fn process_trans_emp_response(&self, qrcode_state: QRCodeState) {


### PR DESCRIPTION
原先的做法将所有类型事件都包裹进 `QEvent` 然后再 match 不同类型事件；重构后允许 handler 固定地处理某种类型事件，更简洁，避免运行时二次判断，同时也便于编译器优化（进一步优化还需要范型）。