### PR TITLE
chore: Add `type_alias_impl_trait` to features

### DIFF
--- a/ricq-core/src/lib.rs
+++ b/ricq-core/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(impl_trait_in_assoc_type)]
 #![feature(type_alias_impl_trait)]
 
 use std::sync::atomic::{AtomicI32, AtomicI64, AtomicU16, Ordering};


### PR DESCRIPTION
This change was introduced by rust-lang/rust#110237 in the latest nightly.